### PR TITLE
Feat/delete round

### DIFF
--- a/index.html
+++ b/index.html
@@ -1557,6 +1557,41 @@
                     </div>
                 </form>
             </div>
+            <div class="modal" tabindex="-1" id="confirmDeleteRoundModal">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Delete Round?</h5>
+                            <button
+                                type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"
+                            ></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>Do you really want to delete that round?</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button
+                                type="button"
+                                class="btn btn-secondary"
+                                data-bs-dismiss="modal"
+                            >
+                                No, Cancel
+                            </button>
+                            <button
+                                type="button"
+                                id="confirmDeleteBtn"
+                                class="btn btn-primary"
+                                onClick=""
+                            >
+                                Yes, Delete Round
+                            </button>
+                        </div>
+                    </div>
+                </div>
+              </div>
         </main>
         <script
             src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -216,7 +216,18 @@ function updateRoundInTable(rowIndex) {
 const thisRound = document.getElementById("r-" + GlobalUserData.rounds[rowIndex].roundNum);
 writeRoundToTable(thisRound,rowIndex);
 }
-
+/*************************************************************************
+ * @function deleteRound
+ * @desc
+ * Deletes a round from the "Rounds" table and from local storage
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if round could be deleted, false otherwise
+ *************************************************************************/
+function deleteRound(roundId) {
+  GlobalUserData.rounds = GlobalUserData.rounds.filter(function (round) {
+      return round.roundNum !== roundId;
+  });
+}
 /*************************************************************************
  * @function confirmDelete
  * @desc

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -218,6 +218,45 @@ writeRoundToTable(thisRound,rowIndex);
 }
 
 /*************************************************************************
+ * @function confirmDelete
+ * @desc
+ * Present pop-up modal dialog asking user to confirm delete operation
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if user confirms delete, false otherwise
+ *************************************************************************/
+function confirmDelete(roundId){
+  //TO DO: Present modal dialog prompting user to confirm delete
+  //Return true if user confirms delete, false otherwise
+  let modal = new bootstrap.Modal(
+      document.getElementById("confirmDeleteRoundModal")
+  );
+  let confirmBtn = document.getElementById("confirmDeleteBtn");
+  confirmBtn.addEventListener("click", function (event) {
+      event.preventDefault();
+      console.log("deleting round with id " + roundId);
+      for (var i = 0; i < GlobalRoundsTable.rows.length; i++) {
+          let row = GlobalRoundsTable.rows[i];
+          // Check if the id of the row matches the id you're looking for
+          if (row.id === "r-" + roundId) {
+              GlobalRoundsTable.deleteRow(i);
+              break;
+          }
+      }
+      deleteRound(roundId);
+      localStorage.setItem(
+          GlobalUserData.accountInfo.email,
+          JSON.stringify(GlobalUserData)
+      );
+      GlobalRoundsTableCaption.textContent =
+          "Table displaying " +
+          (GlobalRoundsTable.rows.length - 1) +
+          " speedgolf rounds";
+      modal.hide();
+  });
+  modal.show();
+}
+
+/*************************************************************************
 * @function populateRoundsTable 
 * @desc 
 * Iterate through the userData.rounds array, adding a row corresponding


### PR DESCRIPTION
## Summary
This PR adds the ability for users to delete a speedgolf round from their history.

## Changes Made
- Added a confirmation modal in `index.html`
- Implemented `confirmDelete()` to show modal and attach event listeners
- Implemented `deleteRound()` to remove the round from localStorage and refresh the table

## Related Issue
Closes #1

## Acceptance Criteria Checklist
- [x] A “Delete” button is visible next to each round listed in the table.
- [x] Clicking the “Delete” button opens a confirmation modal dialog.
- [x] Clicking “Confirm” in the modal deletes the round from the UI.
- [x] The deleted round is removed from local storage.
- [x] Canceling the modal does not delete the round.
